### PR TITLE
Added blackbox testing for movie and review metadata router shape

### DIFF
--- a/backend/tests/test_movie_metadata.py
+++ b/backend/tests/test_movie_metadata.py
@@ -50,6 +50,8 @@ def test_metadata_present_returns_values():
     r = client.get(f"/movies/{movie_id}/metadata")
     assert r.status_code == 200
     data = r.json()
+    # response shape should contain only the expected fields
+    assert set(data.keys()) == {"movie_id", "title", "userRatingAverage", "userRatingCount"}
     assert data["movie_id"] == movie_id
     assert data["title"] == "Test Meta Present"
     assert data["userRatingAverage"] == 8.2
@@ -61,6 +63,8 @@ def test_metadata_missing_returns_defaults():
     r = client.get(f"/movies/{movie_id}/metadata")
     assert r.status_code == 200
     data = r.json()
+    # response shape should contain only the expected fields
+    assert set(data.keys()) == {"movie_id", "title", "userRatingAverage", "userRatingCount"}
     assert data["movie_id"] == movie_id
     # Title may be None if not present; average and count should default
     assert data["userRatingAverage"] == 0.0

--- a/backend/tests/test_reviews_router_validation.py
+++ b/backend/tests/test_reviews_router_validation.py
@@ -1,0 +1,23 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_reviews_invalid_sort_returns_422():
+    r = client.get("/reviews/some-movie?sort=invalid")
+    assert r.status_code == 422
+    data = r.json()
+    assert data["detail"][0]["type"] in ("enum", "enum_member") or data["detail"][0]["type"].endswith("literal_error")
+
+
+def test_reviews_limit_below_min_returns_422():
+    r = client.get("/reviews/some-movie?limit=0")
+    assert r.status_code == 422
+
+
+def test_reviews_offset_negative_returns_422():
+    r = client.get("/reviews/some-movie?offset=-1")
+    assert r.status_code == 422
+
+


### PR DESCRIPTION
Added a black-box test for GET /movies/{movie_id}/metadata that asserts the response includes only movie_id, title, userRatingAverage, and userRatingCount, with defaults when metadata.json is missing. Also added black-box validation tests for the reviews endpoint to ensure invalid sort values, limit below minimum, and negative offsets return 422 errors.