### PR TITLE
Refactor watchlist repository to use JsonFileRepository base

### DIFF
--- a/backend/repositories/json_file_repository.py
+++ b/backend/repositories/json_file_repository.py
@@ -1,0 +1,61 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+
+class JsonFileRepository:
+    """
+    Small reusable helper for repositories that persist a JSON document
+    to disk at a fixed path.
+    """
+
+    def __init__(self, file_path: str, default_data: Dict[str, Any]) -> None:
+        self.path = Path(file_path)
+        self.default_data = default_data
+        self._ensure_file()
+
+    def _ensure_file(self) -> None:
+        """
+        Ensure the JSON file exists on disk with at least the default
+        structure.
+        """
+        if not self.path.exists():
+            os.makedirs(self.path.parent, exist_ok=True)
+            self._write_raw(self.default_data)
+
+    def _read_raw(self) -> Dict[str, Any]:
+        """
+        Load raw JSON from disk. If anything goes wrong, fall back to
+        the default structure.
+        """
+        try:
+            with self.path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return dict(self.default_data)
+
+        if not isinstance(data, dict):
+            return dict(self.default_data)
+
+        return data
+
+    def _write_raw(self, data: Dict[str, Any]) -> None:
+        """
+        Write the given dictionary to disk as pretty-printed JSON.
+        """
+        os.makedirs(self.path.parent, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=4)
+
+    def load(self) -> Dict[str, Any]:
+        """
+        Public API: load the JSON document with defaults applied.
+        """
+        return self._read_raw()
+
+    def save(self, data: Dict[str, Any]) -> None:
+        """
+        Public API: persist the JSON document back to disk.
+        """
+        self._write_raw(data)

--- a/backend/repositories/watchlist_repo.py
+++ b/backend/repositories/watchlist_repo.py
@@ -1,33 +1,25 @@
-import json
-import os
-from typing import List, Dict, Any
+from typing import Dict, Any
+
+from backend.repositories.json_file_repository import JsonFileRepository
 
 
-class WatchlistRepository:
-    def __init__(self, file_path: str):
-        self.file_path = file_path
-        self._ensure_file()
+class WatchlistRepository(JsonFileRepository):
+    """
+    Repository for the watchlist store, backed by a JSON file.
 
-    def _ensure_file(self):
-        """Ensure the JSON file exists and has correct structure."""
-        if not os.path.exists(self.file_path):
-            os.makedirs(os.path.dirname(self.file_path), exist_ok=True)
-            with open(self.file_path, "w", encoding="utf-8") as f:
-                # Standard watchlist structure
-                json.dump({"users": []}, f, indent=4)
+    The underlying JSON structure is normalised to:
 
-    def load(self) -> Dict[str, Any]:
-        """Load the watchlist JSON as a dictionary."""
-        with open(self.file_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+        {"users": [...]}
 
-        # Normalize data structure
-        if "users" not in data or not isinstance(data["users"], list):
-            data = {"users": []}
+    All JSON file I/O is delegated to JsonFileRepository.
+    """
 
-        return data
+    def __init__(self, file_path: str) -> None:
+        # We keep the same public constructor signature but reuse the
+        # shared JSON file handling in the base class.
+        super().__init__(file_path=file_path, default_data={"users": []})
 
-    def save(self, data: Dict[str, Any]) -> None:
-        """Save updated watchlist data back to disk."""
-        with open(self.file_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=4)
+    # If needed in the future, watchlist-specific helpers can be added here,
+    # for example methods to get or update a single user entry.
+    #
+    # For now, we simply inherit load()/save() from JsonFileRepository.


### PR DESCRIPTION
- Introduced a reusable `JsonFileRepository` in `backend/repositories/json_file_repository.py`
  to centralize JSON file I/O and default handling.
- Refactored `WatchlistRepository` to inherit from `JsonFileRepository` instead of
  duplicating file open/load/write logic.
- External behaviour of `WatchlistRepository` remains the same (constructor + load/save),
  but the implementation is now simpler and easier to reuse for other JSON-backed stores.

This is a pure refactor with no functional changes to the watchlist feature.